### PR TITLE
Importing reduce for Python 3 compat

### DIFF
--- a/data_generator.py
+++ b/data_generator.py
@@ -4,6 +4,7 @@ them to the network for training or testing.
 """
 
 from __future__ import absolute_import, division, print_function
+from functools import reduce
 
 import json
 import logging


### PR DESCRIPTION
`reduce` is not in the default namespace in Python 3, and importing it from functools is supported even in Python 2.7 (see https://docs.python.org/2/library/functools.html#functools.reduce).
